### PR TITLE
Errors need to be classes instead of interfaces so that they can be used as values (e.g. with instanceof)

### DIFF
--- a/typescript/spex.d.ts
+++ b/typescript/spex.d.ts
@@ -51,7 +51,7 @@ export interface IArrayExt<T> extends Array<T> {
 export namespace errors {
 
     // API: http://vitaly-t.github.io/spex/errors.BatchError.html
-    interface BatchError extends Error {
+    class BatchError extends Error {
 
         // standard error properties:
         name: string;
@@ -73,7 +73,7 @@ export namespace errors {
     }
 
     // API: http://vitaly-t.github.io/spex/errors.PageError.html
-    interface PageError extends Error {
+    class PageError extends Error {
 
         // standard error properties:
         name: string;
@@ -93,7 +93,7 @@ export namespace errors {
     }
 
     // API: http://vitaly-t.github.io/spex/errors.SequenceError.html
-    interface SequenceError extends Error {
+    class SequenceError extends Error {
 
         // standard error properties:
         name: string;


### PR DESCRIPTION
Example code snippet that did work on earlier spex versions but does not work with current release:

```
import spex from 'spex'
const {BatchError} = spex.errors

..

if (e instanceof BatchError) {
  // proceed to do stuff with e.getErrors()
}
```

This PR will revert the relevant changes made in https://github.com/vitaly-t/spex/pull/17/commits/d9d40f90359719cb1d7e754a858e4307aa80354a#diff-ed54ac027337bce297669fa4cac590aa3fd86567cd32bf84d8fb48881e27d9f7
